### PR TITLE
Fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Kristoffer Dalby
+Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>no.ntnu</groupId>
     <artifactId>okse-broker</artifactId>
-    <version>2.0.0</version>
+    <version>3.0.0</version>
     <packaging>jar</packaging>
 
     <name>OKSE Broker</name>
@@ -166,7 +166,7 @@
         <dependency>
             <groupId>no.ntnu</groupId>
             <artifactId>clients-common</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>asia.stampy</groupId>

--- a/broker/src/main/java/no/ntnu/okse/Application.java
+++ b/broker/src/main/java/no/ntnu/okse/Application.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/core/AbstractCoreService.java
+++ b/broker/src/main/java/no/ntnu/okse/core/AbstractCoreService.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/core/CoreService.java
+++ b/broker/src/main/java/no/ntnu/okse/core/CoreService.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/core/event/Event.java
+++ b/broker/src/main/java/no/ntnu/okse/core/event/Event.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/core/event/PublisherChangeEvent.java
+++ b/broker/src/main/java/no/ntnu/okse/core/event/PublisherChangeEvent.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/core/event/SubscriptionChangeEvent.java
+++ b/broker/src/main/java/no/ntnu/okse/core/event/SubscriptionChangeEvent.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/core/event/SystemEvent.java
+++ b/broker/src/main/java/no/ntnu/okse/core/event/SystemEvent.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/core/event/TopicChangeEvent.java
+++ b/broker/src/main/java/no/ntnu/okse/core/event/TopicChangeEvent.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/core/event/listeners/PublisherChangeListener.java
+++ b/broker/src/main/java/no/ntnu/okse/core/event/listeners/PublisherChangeListener.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/core/event/listeners/SubscriptionChangeListener.java
+++ b/broker/src/main/java/no/ntnu/okse/core/event/listeners/SubscriptionChangeListener.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/core/event/listeners/TopicChangeListener.java
+++ b/broker/src/main/java/no/ntnu/okse/core/event/listeners/TopicChangeListener.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/core/messaging/Message.java
+++ b/broker/src/main/java/no/ntnu/okse/core/messaging/Message.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/core/messaging/MessageService.java
+++ b/broker/src/main/java/no/ntnu/okse/core/messaging/MessageService.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/core/subscription/Publisher.java
+++ b/broker/src/main/java/no/ntnu/okse/core/subscription/Publisher.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/core/subscription/Subscriber.java
+++ b/broker/src/main/java/no/ntnu/okse/core/subscription/Subscriber.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/core/subscription/SubscriptionService.java
+++ b/broker/src/main/java/no/ntnu/okse/core/subscription/SubscriptionService.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/core/subscription/SubscriptionTask.java
+++ b/broker/src/main/java/no/ntnu/okse/core/subscription/SubscriptionTask.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/core/topic/Topic.java
+++ b/broker/src/main/java/no/ntnu/okse/core/topic/Topic.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/core/topic/TopicService.java
+++ b/broker/src/main/java/no/ntnu/okse/core/topic/TopicService.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/core/topic/TopicTask.java
+++ b/broker/src/main/java/no/ntnu/okse/core/topic/TopicTask.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/core/topic/TopicTools.java
+++ b/broker/src/main/java/no/ntnu/okse/core/topic/TopicTools.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/db/DB.java
+++ b/broker/src/main/java/no/ntnu/okse/db/DB.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/examples/DummyProtocolServer.java
+++ b/broker/src/main/java/no/ntnu/okse/examples/DummyProtocolServer.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/exceptions/TopicExceptions.java
+++ b/broker/src/main/java/no/ntnu/okse/exceptions/TopicExceptions.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/protocol/AbstractProtocolServer.java
+++ b/broker/src/main/java/no/ntnu/okse/protocol/AbstractProtocolServer.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/protocol/ProtocolServer.java
+++ b/broker/src/main/java/no/ntnu/okse/protocol/ProtocolServer.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/protocol/amqp/AMQPServer.java
+++ b/broker/src/main/java/no/ntnu/okse/protocol/amqp/AMQPServer.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/protocol/amqp/AMQProtocolServer.java
+++ b/broker/src/main/java/no/ntnu/okse/protocol/amqp/AMQProtocolServer.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/protocol/amqp/Driver.java
+++ b/broker/src/main/java/no/ntnu/okse/protocol/amqp/Driver.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/protocol/amqp/FlowController.java
+++ b/broker/src/main/java/no/ntnu/okse/protocol/amqp/FlowController.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/protocol/amqp/Handshaker.java
+++ b/broker/src/main/java/no/ntnu/okse/protocol/amqp/Handshaker.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/protocol/amqp/MessageBytes.java
+++ b/broker/src/main/java/no/ntnu/okse/protocol/amqp/MessageBytes.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/protocol/amqp/SubscriptionHandler.java
+++ b/broker/src/main/java/no/ntnu/okse/protocol/amqp/SubscriptionHandler.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/protocol/wsn/WSNCommandProxy.java
+++ b/broker/src/main/java/no/ntnu/okse/protocol/wsn/WSNCommandProxy.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/protocol/wsn/WSNRegistrationManager.java
+++ b/broker/src/main/java/no/ntnu/okse/protocol/wsn/WSNRegistrationManager.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/protocol/wsn/WSNRequestParser.java
+++ b/broker/src/main/java/no/ntnu/okse/protocol/wsn/WSNRequestParser.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/protocol/wsn/WSNTools.java
+++ b/broker/src/main/java/no/ntnu/okse/protocol/wsn/WSNTools.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/protocol/wsn/WSNotificationServer.java
+++ b/broker/src/main/java/no/ntnu/okse/protocol/wsn/WSNotificationServer.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/protocol/xmpp/XMPPProtocolServer.java
+++ b/broker/src/main/java/no/ntnu/okse/protocol/xmpp/XMPPProtocolServer.java
@@ -96,7 +96,7 @@ public class XMPPProtocolServer extends AbstractProtocolServer {
       try {
         server.sendMessage(message);
         incrementTotalMessagesSent();
-      } catch (NotAPubSubNodeException | XMPPErrorException | NoResponseException | InterruptedException e) {
+      } catch (NotAPubSubNodeException | NoResponseException | InterruptedException e) {
         incrementTotalErrors();
         e.printStackTrace();
       } catch (NotConnectedException e) {

--- a/broker/src/main/java/no/ntnu/okse/web/DatabaseConfig.java
+++ b/broker/src/main/java/no/ntnu/okse/web/DatabaseConfig.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/web/Server.java
+++ b/broker/src/main/java/no/ntnu/okse/web/Server.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/web/WebSecurityConfig.java
+++ b/broker/src/main/java/no/ntnu/okse/web/WebSecurityConfig.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/web/controller/IndexViewController.java
+++ b/broker/src/main/java/no/ntnu/okse/web/controller/IndexViewController.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/web/controller/LogController.java
+++ b/broker/src/main/java/no/ntnu/okse/web/controller/LogController.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/web/controller/MainController.java
+++ b/broker/src/main/java/no/ntnu/okse/web/controller/MainController.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/web/controller/StatsController.java
+++ b/broker/src/main/java/no/ntnu/okse/web/controller/StatsController.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/web/controller/SubscriberController.java
+++ b/broker/src/main/java/no/ntnu/okse/web/controller/SubscriberController.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/web/controller/TopicController.java
+++ b/broker/src/main/java/no/ntnu/okse/web/controller/TopicController.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/web/model/Log.java
+++ b/broker/src/main/java/no/ntnu/okse/web/model/Log.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/java/no/ntnu/okse/web/model/ProtocolStats.java
+++ b/broker/src/main/java/no/ntnu/okse/web/model/ProtocolStats.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/resources/config/gateway.properties
+++ b/broker/src/main/resources/config/gateway.properties
@@ -57,7 +57,7 @@ willTopic = test
 willMessage = bye
 
 #the maximum length of the Mqtts message
-maxMqttsLength = 60
+maxMqttsLength = 1000
 
 #the minimum length of the Mqtts message
 minMqttsLength = 2

--- a/broker/src/main/resources/config/log4j.properties
+++ b/broker/src/main/resources/config/log4j.properties
@@ -1,7 +1,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+# Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/resources/config/okse.properties
+++ b/broker/src/main/resources/config/okse.properties
@@ -1,7 +1,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+# Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/resources/config/topicmapping.properties
+++ b/broker/src/main/resources/config/topicmapping.properties
@@ -1,7 +1,7 @@
 #
 # The MIT License (MIT)
 #
-# Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+# Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/resources/static/css/style.css
+++ b/broker/src/main/resources/static/css/style.css
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/resources/static/js/config.js
+++ b/broker/src/main/resources/static/js/config.js
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/resources/static/js/logs.js
+++ b/broker/src/main/resources/static/js/logs.js
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/resources/static/js/main.js
+++ b/broker/src/main/resources/static/js/main.js
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/resources/static/js/stats.js
+++ b/broker/src/main/resources/static/js/stats.js
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/resources/static/js/topics.js
+++ b/broker/src/main/resources/static/js/topics.js
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/main/resources/templates/layout.html
+++ b/broker/src/main/resources/templates/layout.html
@@ -77,7 +77,7 @@
             </div>
             <div class="row row-top-spacing">
                 <div class="col-md-12">
-                    <div id="footer">Copyright &copy; 2015 - 2016 Norwegian Defence Research Establishment / NTNU</div>
+                    <div id="footer">Copyright &copy; 2015 - 2018 Norwegian Defence Research Establishment / NTNU</div>
                 </div>
             </div>
         </div>

--- a/broker/src/main/resources/templates/layout.html
+++ b/broker/src/main/resources/templates/layout.html
@@ -1,7 +1,7 @@
 <!--
   ~ The MIT License (MIT)
   ~
-  ~ Copyright (c) 2015 - 2016 Norwegian Defence Research Establishment / NTNU
+  ~ Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/test/java/no/ntnu/okse/ApplicationTest.java
+++ b/broker/src/test/java/no/ntnu/okse/ApplicationTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/test/java/no/ntnu/okse/core/CoreServiceTest.java
+++ b/broker/src/test/java/no/ntnu/okse/core/CoreServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/test/java/no/ntnu/okse/core/UtilitiesTest.java
+++ b/broker/src/test/java/no/ntnu/okse/core/UtilitiesTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/test/java/no/ntnu/okse/core/event/PublisherChangeEventTest.java
+++ b/broker/src/test/java/no/ntnu/okse/core/event/PublisherChangeEventTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/test/java/no/ntnu/okse/core/event/SubscriptionChangeEventTest.java
+++ b/broker/src/test/java/no/ntnu/okse/core/event/SubscriptionChangeEventTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/test/java/no/ntnu/okse/core/event/SystemEventTest.java
+++ b/broker/src/test/java/no/ntnu/okse/core/event/SystemEventTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/test/java/no/ntnu/okse/core/event/TopicChangeEventTest.java
+++ b/broker/src/test/java/no/ntnu/okse/core/event/TopicChangeEventTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/test/java/no/ntnu/okse/core/messaging/MessageServiceTest.java
+++ b/broker/src/test/java/no/ntnu/okse/core/messaging/MessageServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/test/java/no/ntnu/okse/core/messaging/MessageTest.java
+++ b/broker/src/test/java/no/ntnu/okse/core/messaging/MessageTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/test/java/no/ntnu/okse/core/subscription/PublisherTest.java
+++ b/broker/src/test/java/no/ntnu/okse/core/subscription/PublisherTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/test/java/no/ntnu/okse/core/subscription/SubscriberTest.java
+++ b/broker/src/test/java/no/ntnu/okse/core/subscription/SubscriberTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/test/java/no/ntnu/okse/core/subscription/SubscriptionTaskTest.java
+++ b/broker/src/test/java/no/ntnu/okse/core/subscription/SubscriptionTaskTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/test/java/no/ntnu/okse/core/topic/TopicServiceTest.java
+++ b/broker/src/test/java/no/ntnu/okse/core/topic/TopicServiceTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/test/java/no/ntnu/okse/core/topic/TopicTest.java
+++ b/broker/src/test/java/no/ntnu/okse/core/topic/TopicTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/test/java/no/ntnu/okse/core/topic/TopicToolsTest.java
+++ b/broker/src/test/java/no/ntnu/okse/core/topic/TopicToolsTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/test/java/no/ntnu/okse/db/DBTest.java
+++ b/broker/src/test/java/no/ntnu/okse/db/DBTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/test/java/no/ntnu/okse/protocol/MessageSendingTest.java
+++ b/broker/src/test/java/no/ntnu/okse/protocol/MessageSendingTest.java
@@ -253,8 +253,7 @@ public class MessageSendingTest extends FullMessageFunctionalityTest {
     verify(amqpCallback, times(numberOfProtocols)).onReceive(any());
     verify(mqttCallback, times(numberOfProtocols))
         .messageArrived(anyString(), any(MqttMessage.class));
-    // MQTT-SN test client will not receive its own messages to a topic it is subscribed to
-    verify(mqttsnCallback, times(numberOfProtocols - 1))
+    verify(mqttsnCallback, times(numberOfProtocols))
         .publishArrived(anyBoolean(), anyInt(), anyString(), any());
     verify(amqp091Callback, times(numberOfProtocols)).messageReceived(any(), any());
     verify(wsnCallback, times(numberOfProtocols)).notify(any());

--- a/broker/src/test/java/no/ntnu/okse/protocol/MessageSendingTest.java
+++ b/broker/src/test/java/no/ntnu/okse/protocol/MessageSendingTest.java
@@ -140,8 +140,8 @@ public class MessageSendingTest extends FullMessageFunctionalityTest {
 
   @Test
   public void xmppToXmpp() throws Exception {
-    XMPPClient client1 = new XMPPClient("localhost", 5222, "okse1@localhost");
-    XMPPClient client2 = new XMPPClient("localhost", 5222, "okse2@localhost");
+    XMPPClient client1 = new XMPPClient("localhost", 5222, "okse1@localhost", "pass");
+    XMPPClient client2 = new XMPPClient("localhost", 5222, "okse2@localhost", "pass");
     client1.connect();
     client2.connect();
     client1.subscribe("xmpp");
@@ -198,7 +198,7 @@ public class MessageSendingTest extends FullMessageFunctionalityTest {
     stompClient.setCallback(stompCallback);
 
     // XMPP
-    XMPPClient xmppClient = new XMPPClient("localhost", 5222, "okse1@localhost");
+    XMPPClient xmppClient = new XMPPClient("localhost", 5222, "okse1@localhost", "pass");
 
     // Connecting
     mqttClient.connect();

--- a/broker/src/test/java/no/ntnu/okse/protocol/amqp/AMQPServerTest.java
+++ b/broker/src/test/java/no/ntnu/okse/protocol/amqp/AMQPServerTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/test/java/no/ntnu/okse/protocol/wsn/WSNSubscriptionManagerTest.java
+++ b/broker/src/test/java/no/ntnu/okse/protocol/wsn/WSNSubscriptionManagerTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/test/java/no/ntnu/okse/protocol/wsn/WSNToolsTest.java
+++ b/broker/src/test/java/no/ntnu/okse/protocol/wsn/WSNToolsTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ * Copyright (c) 2015 - 2018 Norwegian Defence Research Establishment / NTNU
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/broker/src/test/java/no/ntnu/okse/protocol/xmpp/XMPPClientTest.java
+++ b/broker/src/test/java/no/ntnu/okse/protocol/xmpp/XMPPClientTest.java
@@ -29,9 +29,9 @@ public class XMPPClientTest {
     Thread.sleep(1000);
 
     //Creates and connects clients
-    client = new XMPPClient("localhost", 5222, "test-client-1@localhost");
+    client = new XMPPClient("localhost", 5222, "test-client-1@localhost", "password");
     client.connect();
-    client2 = new XMPPClient("localhost", 5222, "test-client-2@localhost");
+    client2 = new XMPPClient("localhost", 5222, "test-client-2@localhost", "password");
     client2.connect();
 
     //Field access control

--- a/clients/amqp-publisher/pom.xml
+++ b/clients/amqp-publisher/pom.xml
@@ -45,6 +45,7 @@
                 </executions>
             </plugin>
         </plugins>
+        <finalName>${project.artifactId}</finalName>
     </build>
     <dependencies>
         <dependency>

--- a/clients/amqp-publisher/pom.xml
+++ b/clients/amqp-publisher/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>okse-clients</artifactId>
         <groupId>no.ntnu</groupId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>no.ntnu</groupId>
             <artifactId>clients-common</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/clients/amqp-publisher/src/main/java/no/ntnu/okse/clients/amqp/AMQPPublisher.java
+++ b/clients/amqp-publisher/src/main/java/no/ntnu/okse/clients/amqp/AMQPPublisher.java
@@ -7,7 +7,7 @@ import no.ntnu.okse.clients.TestClient;
 public class AMQPPublisher extends PublishClient {
 
   @Parameter(names = {"--port", "-p"}, description = "Port")
-  public final int port = 5672;
+  public int port = 5672;
 
   private AMQPClient client;
 

--- a/clients/amqp-subscriber/pom.xml
+++ b/clients/amqp-subscriber/pom.xml
@@ -45,6 +45,7 @@
                 </executions>
             </plugin>
         </plugins>
+        <finalName>${project.artifactId}</finalName>
     </build>
     <dependencies>
         <dependency>

--- a/clients/amqp-subscriber/pom.xml
+++ b/clients/amqp-subscriber/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>okse-clients</artifactId>
         <groupId>no.ntnu</groupId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>no.ntnu</groupId>
             <artifactId>clients-common</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/clients/amqp-subscriber/src/main/java/no/ntnu/okse/clients/amqp/AMQPSubscriber.java
+++ b/clients/amqp-subscriber/src/main/java/no/ntnu/okse/clients/amqp/AMQPSubscriber.java
@@ -21,7 +21,7 @@ public class AMQPSubscriber extends SubscribeClient {
     client = new AMQPClient();
     // Prevent subscriber from timing out
     client.setTimeout(-1L);
-    client.setCallback(new Callback());
+    client.setCallback(new Callback(this));
   }
 
   protected TestClient getClient() {
@@ -30,12 +30,17 @@ public class AMQPSubscriber extends SubscribeClient {
 
   private static class Callback implements AMQPCallback {
 
-    private final boolean verbose = false;
-    private int counter = 0;
+    private SubscribeClient subscribeClient;
+
+    public Callback(SubscribeClient subscribeClient) {
+      this.subscribeClient = subscribeClient;
+    }
+
+    private int counter;
 
     public void onReceive(Message message) {
-      counter++;
-      print(counter, message, verbose);
+      print(++counter, message, subscribeClient.verbose);
+      subscribeClient.receiveMessage("", "", false);
     }
   }
 

--- a/clients/amqp091-publisher/pom.xml
+++ b/clients/amqp091-publisher/pom.xml
@@ -45,6 +45,7 @@
                 </executions>
             </plugin>
         </plugins>
+        <finalName>${project.artifactId}</finalName>
     </build>
     <dependencies>
         <dependency>

--- a/clients/amqp091-publisher/pom.xml
+++ b/clients/amqp091-publisher/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>okse-clients</artifactId>
         <groupId>no.ntnu</groupId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>no.ntnu</groupId>
             <artifactId>clients-common</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/clients/amqp091-publisher/src/main/java/no/ntnu/okse/clients/amqp091/AMQP091Publisher.java
+++ b/clients/amqp091-publisher/src/main/java/no/ntnu/okse/clients/amqp091/AMQP091Publisher.java
@@ -7,7 +7,7 @@ import no.ntnu.okse.clients.TestClient;
 public class AMQP091Publisher extends PublishClient {
 
   @Parameter(names = {"--port", "-p"}, description = "Port")
-  public final int port = 56720;
+  public int port = 56720;
 
   private AMQP091Client client;
 

--- a/clients/amqp091-subscriber/pom.xml
+++ b/clients/amqp091-subscriber/pom.xml
@@ -45,6 +45,7 @@
                 </executions>
             </plugin>
         </plugins>
+        <finalName>${project.artifactId}</finalName>
     </build>
     <dependencies>
         <dependency>

--- a/clients/amqp091-subscriber/pom.xml
+++ b/clients/amqp091-subscriber/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>okse-clients</artifactId>
         <groupId>no.ntnu</groupId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>no.ntnu</groupId>
             <artifactId>clients-common</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/clients/amqp091-subscriber/src/main/java/no/ntnu/okse/clients/amqp091/AMQP091Subscriber.java
+++ b/clients/amqp091-subscriber/src/main/java/no/ntnu/okse/clients/amqp091/AMQP091Subscriber.java
@@ -7,7 +7,7 @@ import no.ntnu.okse.clients.TestClient;
 public class AMQP091Subscriber extends SubscribeClient {
 
   @Parameter(names = {"--port", "-p"}, description = "Port")
-  public final int port = 56720;
+  public int port = 56720;
 
   private AMQP091Client client;
 

--- a/clients/amqp091-subscriber/src/main/java/no/ntnu/okse/clients/amqp091/AMQP091Subscriber.java
+++ b/clients/amqp091-subscriber/src/main/java/no/ntnu/okse/clients/amqp091/AMQP091Subscriber.java
@@ -17,7 +17,7 @@ public class AMQP091Subscriber extends SubscribeClient {
 
   protected void createClient() {
     client = new AMQP091Client(host, port);
-    client.setCallback(new SubscriberCallback());
+    client.setCallback(new SubscriberCallback(this));
   }
 
   protected TestClient getClient() {
@@ -26,10 +26,14 @@ public class AMQP091Subscriber extends SubscribeClient {
 
   private class SubscriberCallback implements AMQP091Callback {
 
-    private int messagesReceived = 0;
+    private SubscribeClient subscribeClient;
+
+    public SubscriberCallback(SubscribeClient subscribeClient) {
+      this.subscribeClient = subscribeClient;
+    }
 
     public void messageReceived(String topic, String message) {
-      System.out.println(String.format("#%d [%s] %s", ++messagesReceived, topic, message));
+      subscribeClient.receiveMessage(topic, message, true);
     }
   }
 }

--- a/clients/common/pom.xml
+++ b/clients/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>okse-clients</artifactId>
         <groupId>no.ntnu</groupId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/clients/common/pom.xml
+++ b/clients/common/pom.xml
@@ -115,6 +115,12 @@
             <artifactId>MQTT-SN-UDP-Client</artifactId>
             <version>1.1.1-OKSE</version>
         </dependency>
+      <dependency>
+        <groupId>org.igniterealtime.openfire</groupId>
+        <artifactId>xmppserver</artifactId>
+        <version>4.2.2-okse</version>
+        <scope>compile</scope>
+      </dependency>
     </dependencies>
 
     <repositories>

--- a/clients/common/src/main/java/no/ntnu/okse/clients/CommandClient.java
+++ b/clients/common/src/main/java/no/ntnu/okse/clients/CommandClient.java
@@ -13,13 +13,13 @@ import java.util.List;
 abstract class CommandClient {
 
   @Parameter(names = {"--host"}, description = "Server hostname")
-  public final String host = "localhost";
+  public String host = "localhost";
 
   @Parameter(names = {"--topic", "-t"}, description = "Topic", required = true)
   public List<String> topics;
 
   @Parameter(names = {"--verbose", "-v"}, description = "Verbose")
-  public final boolean verbose = false;
+  public boolean verbose = false;
 
   @Parameter(names = {"--help", "-h"}, help = true, hidden = true)
   public boolean help;

--- a/clients/common/src/main/java/no/ntnu/okse/clients/PublishClient.java
+++ b/clients/common/src/main/java/no/ntnu/okse/clients/PublishClient.java
@@ -8,7 +8,7 @@ public abstract class PublishClient extends CommandClient {
   public String message;
 
   @Parameter(names = {"-n"}, description = "Number of messages to send")
-  public final int numberOfMessages = 1;
+  public int numberOfMessages = 1;
 
   public void run() {
     initLogger();

--- a/clients/common/src/main/java/no/ntnu/okse/clients/SubscribeClient.java
+++ b/clients/common/src/main/java/no/ntnu/okse/clients/SubscribeClient.java
@@ -1,6 +1,13 @@
 package no.ntnu.okse.clients;
 
+import com.beust.jcommander.Parameter;
+
 public abstract class SubscribeClient extends CommandClient {
+
+  @Parameter(names = {"-n"}, description = "Number of messages to receive")
+  public int numberOfMessages = Integer.MAX_VALUE;
+
+  private int numberOfReceivedMessages = 0;
 
   public void run() {
     initLogger();
@@ -23,5 +30,17 @@ public abstract class SubscribeClient extends CommandClient {
 
   public void subscribe(String topic) {
     getClient().subscribe(topic);
+  }
+
+  public void receiveMessage(String topic, String message, boolean shouldPrint) {
+    numberOfReceivedMessages++;
+    if (shouldPrint) {
+      System.out.println(String.format("Recieved message #%d on topic %s with content %s",
+          numberOfReceivedMessages, topic, message));
+    }
+    if (numberOfMessages == numberOfReceivedMessages) {
+      System.out.println("Received indicated number of messages, un-subscribing and disconnecting");
+      System.exit(0);
+    }
   }
 }

--- a/clients/common/src/main/java/no/ntnu/okse/clients/SubscribeClient.java
+++ b/clients/common/src/main/java/no/ntnu/okse/clients/SubscribeClient.java
@@ -1,25 +1,29 @@
 package no.ntnu.okse.clients;
 
 import com.beust.jcommander.Parameter;
+import java.util.Date;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public abstract class SubscribeClient extends CommandClient {
 
   @Parameter(names = {"-n"}, description = "Number of messages to receive")
   public int numberOfMessages = Integer.MAX_VALUE;
 
-  private int numberOfReceivedMessages = 0;
+  private AtomicInteger numberOfReceivedMessages = new AtomicInteger(0);
+  private Thread shutdownHook;
+  private TestClient client;
 
   public void run() {
     initLogger();
     createClient();
-    TestClient client = getClient();
+    client = getClient();
     client.connect();
     topics.forEach(this::subscribe);
     // Graceful disconnect
-    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-      topics.forEach(client::unsubscribe);
-      client.disconnect();
-    }));
+    shutdownHook = new Thread(() -> shutdown(true));
+    Runtime.getRuntime().addShutdownHook(shutdownHook);
     System.out.println("Listening for messages...");
     try {
       Thread.sleep(10000000);
@@ -33,13 +37,34 @@ public abstract class SubscribeClient extends CommandClient {
   }
 
   public void receiveMessage(String topic, String message, boolean shouldPrint) {
-    numberOfReceivedMessages++;
+    int messageNumber = numberOfReceivedMessages.incrementAndGet();
     if (shouldPrint) {
       System.out.println(String.format("Recieved message #%d on topic %s with content %s",
-          numberOfReceivedMessages, topic, message));
+          messageNumber, topic, message));
     }
-    if (numberOfMessages == numberOfReceivedMessages) {
+    if (numberOfMessages == messageNumber) {
       System.out.println("Received indicated number of messages, un-subscribing and disconnecting");
+      Runtime.getRuntime().removeShutdownHook(shutdownHook);
+      // In case the unsubscribe/disconnect is not working correctly
+      new Timer().schedule(new TimerTask() {
+        @Override
+        public void run() {
+          System.out
+              .println("Un-subscribing and disconnect is taking too long. Forcing a shutdown");
+          System.exit(1);
+        }
+      }, new Date(System.currentTimeMillis() + 10000));
+      new Thread(() -> shutdown(false)).start();
+    }
+  }
+
+  private void shutdown(boolean isHook) {
+    try {
+      topics.forEach(client::unsubscribe);
+    } catch (Exception ignored) {
+    }
+    client.disconnect();
+    if (!isHook) {
       System.exit(0);
     }
   }

--- a/clients/common/src/main/java/no/ntnu/okse/clients/mqttsn/MQTTSNClient.java
+++ b/clients/common/src/main/java/no/ntnu/okse/clients/mqttsn/MQTTSNClient.java
@@ -23,4 +23,16 @@ public class MQTTSNClient extends SimpleMqttsClient implements TestClient {
   public void publish(String topic, String content) {
     publish(topic, content.getBytes());
   }
+
+  /**
+   * Need to convert content to bytes to be able to use the base class
+   */
+  public void publish(String topic, String content, int qos) {
+    publish(topic, content.getBytes(), qos, false);
+  }
+
+  @Override
+  public void subscribe(String topic) {
+    subscribe(topic, 0);
+  }
 }

--- a/clients/common/src/main/java/no/ntnu/okse/clients/wsn/TestNotificationBroker.java
+++ b/clients/common/src/main/java/no/ntnu/okse/clients/wsn/TestNotificationBroker.java
@@ -17,16 +17,19 @@
 
 package no.ntnu.okse.clients.wsn;
 
+import static org.apache.cxf.wsn.jms.JmsTopicExpressionConverter.SIMPLE_DIALECT;
+
+import javax.xml.bind.JAXBElement;
+import org.apache.cxf.wsn.client.Consumer;
 import org.apache.cxf.wsn.client.NotificationBroker;
 import org.apache.cxf.wsn.client.Referencable;
 import org.apache.cxf.wsn.client.Subscription;
-import org.oasis_open.docs.wsn.b_2.*;
-import org.oasis_open.docs.wsn.bw_2.*;
-import org.oasis_open.docs.wsrf.rw_2.ResourceUnknownFault;
-
-import javax.xml.bind.JAXBElement;
-
-import static org.apache.cxf.wsn.jms.JmsTopicExpressionConverter.SIMPLE_DIALECT;
+import org.oasis_open.docs.wsn.b_2.FilterType;
+import org.oasis_open.docs.wsn.b_2.NotificationMessageHolderType;
+import org.oasis_open.docs.wsn.b_2.Notify;
+import org.oasis_open.docs.wsn.b_2.Subscribe;
+import org.oasis_open.docs.wsn.b_2.SubscribeResponse;
+import org.oasis_open.docs.wsn.b_2.TopicExpressionType;
 
 public class TestNotificationBroker extends NotificationBroker {
 
@@ -34,42 +37,16 @@ public class TestNotificationBroker extends NotificationBroker {
     super(address, cls);
   }
 
-  public Subscription subscribe(Referencable consumer, String topic,
-      String xpath, boolean raw, String initialTerminationTime)
-      throws TopicNotSupportedFault, InvalidFilterFault, TopicExpressionDialectUnknownFault,
-      UnacceptableInitialTerminationTimeFault, SubscribeCreationFailedFault,
-      InvalidMessageContentExpressionFault, InvalidTopicExpressionFault, UnrecognizedPolicyRequestFault,
-      UnsupportedPolicyRequestFault, ResourceUnknownFault, NotifyMessageNotSupportedFault,
-      InvalidProducerPropertiesExpressionFault {
+  public Subscription subscribe(Consumer consumer, String topic) throws Exception {
     Subscribe subscribeRequest = new Subscribe();
-    if (initialTerminationTime != null) {
-      subscribeRequest.setInitialTerminationTime(
-          new JAXBElement<>(QNAME_INITIAL_TERMINATION_TIME,
-              String.class, initialTerminationTime));
-    }
     subscribeRequest.setConsumerReference(consumer.getEpr());
     subscribeRequest.setFilter(new FilterType());
-    if (topic != null) {
-      TopicExpressionType topicExp = new TopicExpressionType();
-      // Modified: Added dialect
-      topicExp.setDialect(SIMPLE_DIALECT);
-      topicExp.getContent().add(topic);
-      subscribeRequest.getFilter().getAny().add(
-          new JAXBElement<>(QNAME_TOPIC_EXPRESSION,
-              TopicExpressionType.class, topicExp));
-    }
-    if (xpath != null) {
-      QueryExpressionType xpathExp = new QueryExpressionType();
-      xpathExp.setDialect(XPATH1_URI);
-      xpathExp.getContent().add(xpath);
-      subscribeRequest.getFilter().getAny().add(
-          new JAXBElement<>(QNAME_MESSAGE_CONTENT,
-              QueryExpressionType.class, xpathExp));
-    }
-    if (raw) {
-      subscribeRequest.setSubscriptionPolicy(new Subscribe.SubscriptionPolicy());
-      subscribeRequest.getSubscriptionPolicy().getAny().add(new UseRaw());
-    }
+    TopicExpressionType topicExp = new TopicExpressionType();
+    topicExp.setDialect("http://docs.oasis-open.org/wsn/t-1/TopicExpression/Simple");
+    topicExp.getContent().add(topic);
+    subscribeRequest.getFilter().getAny()
+        .add(new JAXBElement<>(QNAME_TOPIC_EXPRESSION, TopicExpressionType.class, topicExp));
+
     SubscribeResponse response = getBroker().subscribe(subscribeRequest);
     return new Subscription(response.getSubscriptionReference());
   }
@@ -88,8 +65,7 @@ public class TestNotificationBroker extends NotificationBroker {
     }
     if (topic != null) {
       TopicExpressionType topicExp = new TopicExpressionType();
-      // Modified: Added dialect
-      topicExp.setDialect(SIMPLE_DIALECT);
+      topicExp.setDialect("http://docs.oasis-open.org/wsn/t-1/TopicExpression/Simple");
       topicExp.getContent().add(topic);
       holder.setTopic(topicExp);
     }

--- a/clients/common/src/main/java/no/ntnu/okse/clients/wsn/WSNClient.java
+++ b/clients/common/src/main/java/no/ntnu/okse/clients/wsn/WSNClient.java
@@ -17,6 +17,7 @@
 package no.ntnu.okse.clients.wsn;
 
 import no.ntnu.okse.clients.TestClient;
+import org.apache.cxf.wsn.client.NotificationBroker;
 import org.apache.log4j.Logger;
 import org.oasis_open.docs.wsn.bw_2.UnableToDestroySubscriptionFault;
 import org.oasis_open.docs.wsrf.rw_2.ResourceUnknownFault;
@@ -31,31 +32,22 @@ import java.util.Map;
 public final class WSNClient implements TestClient {
 
   private static final Logger log = Logger.getLogger(WSNClient.class);
+  private static final String DEFAULT_URL_EXTENSION = "";
   private static final String DEFAULT_HOST = "localhost";
   private static final int DEFAULT_PORT = 61000;
   private final TestNotificationBroker notificationBroker;
-  private final Map<String, Subscription> subscriptions;
-  private final Map<String, Consumer> consumers;
+  private final Map<String, Subscription> subscriptions = new HashMap<>();
+  private final Map<String, Consumer> consumers = new HashMap<>();
   private Consumer.Callback callback;
 
 
   public WSNClient() {
-    this(DEFAULT_HOST, DEFAULT_PORT);
+    this(DEFAULT_HOST, DEFAULT_PORT, DEFAULT_URL_EXTENSION);
   }
 
-  public WSNClient(String host, int port) {
-    subscriptions = new HashMap<>();
-    consumers = new HashMap<>();
-    notificationBroker = new TestNotificationBroker(String.format("http://%s:%d", host, port));
-  }
-
-  public static void main(String[] args) throws Exception {
-    WSNClient client = new WSNClient();
-    client.subscribe("example");
-    client.publish("example", "Hello World!");
-    Thread.sleep(5000);
-    client.unsubscribe("example");
-    System.exit(0);
+  public WSNClient(String host, int port, String url_extension) {
+    notificationBroker = new TestNotificationBroker(
+        String.format("http://%s:%d/%s", host, port, url_extension));
   }
 
   @Override
@@ -111,9 +103,7 @@ public final class WSNClient implements TestClient {
   @Override
   public void publish(String topic, String content) {
     log.debug(String.format("Publishing to topic %s with content %s", topic, content));
-    // TODO: Try to get rid of JAXB element wrapping
-    notificationBroker.notify(topic, new JAXBElement<>(
-        new QName("string"), String.class, content));
+    notificationBroker.notify(topic, new JAXBElement<>(new QName("string"), String.class, content));
     log.debug("Published message successfully");
   }
 

--- a/clients/common/src/main/java/no/ntnu/okse/clients/xmpp/XMPPClient.java
+++ b/clients/common/src/main/java/no/ntnu/okse/clients/xmpp/XMPPClient.java
@@ -40,7 +40,7 @@ import org.jxmpp.stringprep.XmppStringprepException;
 public class XMPPClient implements TestClient {
 
   private EntityBareJid jid;
-  private String password;
+  private String password = "Password";
   private String serverHost;
   private Integer serverPort;
   public int messageCounter;
@@ -49,21 +49,20 @@ public class XMPPClient implements TestClient {
   private ConcurrentHashMap<String, ItemEventListener> listenerMap;
   protected Callback callback;
 
-  public XMPPClient(String host, Integer port, String jid) {
+  public XMPPClient(String host, Integer port, String jid, String password) {
     try {
       this.jid = JidCreate.entityBareFrom(jid);
     } catch (XmppStringprepException e) {
       e.printStackTrace();
     }
-    password = "Password";
     listenerMap = new ConcurrentHashMap<>();
     serverHost = host;
-    messageCounter = 0;
     serverPort = port;
+    this.password = password;
   }
 
   public XMPPClient(String host, Integer port) {
-    this(host, port, "testclient@127.0.0.1");
+    this(host, port, "testclient@127.0.0.1", "password");
   }
 
   private XMPPTCPConnection setUpConnection(String host, Integer port) {

--- a/clients/mqtt-publisher/pom.xml
+++ b/clients/mqtt-publisher/pom.xml
@@ -46,6 +46,7 @@
                 </executions>
             </plugin>
         </plugins>
+        <finalName>${project.artifactId}</finalName>
     </build>
     <dependencies>
         <dependency>

--- a/clients/mqtt-publisher/pom.xml
+++ b/clients/mqtt-publisher/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>okse-clients</artifactId>
         <groupId>no.ntnu</groupId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>no.ntnu</groupId>
             <artifactId>clients-common</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/clients/mqtt-publisher/src/main/java/no/ntnu/okse/clients/mqtt/MQTTPublisher.java
+++ b/clients/mqtt-publisher/src/main/java/no/ntnu/okse/clients/mqtt/MQTTPublisher.java
@@ -7,9 +7,9 @@ import no.ntnu.okse.clients.TestClient;
 public class MQTTPublisher extends PublishClient {
 
   @Parameter(names = {"--port", "-p"}, description = "Port")
-  public final int port = 1883;
+  public int port = 1883;
   @Parameter(names = {"--qos", "-q"}, description = "Quality of Service")
-  public final int qos = 0;
+  public int qos = 0;
 
   private MQTTClient client;
 

--- a/clients/mqtt-sn-publisher/pom.xml
+++ b/clients/mqtt-sn-publisher/pom.xml
@@ -46,6 +46,7 @@
                 </executions>
             </plugin>
         </plugins>
+        <finalName>${project.artifactId}</finalName>
     </build>
     <dependencies>
         <dependency>

--- a/clients/mqtt-sn-publisher/pom.xml
+++ b/clients/mqtt-sn-publisher/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>okse-clients</artifactId>
         <groupId>no.ntnu</groupId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>no.ntnu</groupId>
             <artifactId>clients-common</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/clients/mqtt-sn-publisher/src/main/java/no/ntnu/okse/clients/mqttsn/MQTTSNPublisher.java
+++ b/clients/mqtt-sn-publisher/src/main/java/no/ntnu/okse/clients/mqttsn/MQTTSNPublisher.java
@@ -7,7 +7,7 @@ import no.ntnu.okse.clients.TestClient;
 public class MQTTSNPublisher extends PublishClient {
 
   @Parameter(names = {"--port", "-p"}, description = "Port")
-  public final int port = 20000;
+  public int port = 20000;
 
   private MQTTSNClient client;
 

--- a/clients/mqtt-sn-publisher/src/main/java/no/ntnu/okse/clients/mqttsn/MQTTSNPublisher.java
+++ b/clients/mqtt-sn-publisher/src/main/java/no/ntnu/okse/clients/mqttsn/MQTTSNPublisher.java
@@ -9,6 +9,9 @@ public class MQTTSNPublisher extends PublishClient {
   @Parameter(names = {"--port", "-p"}, description = "Port")
   public int port = 20000;
 
+  @Parameter(names = {"--qos", "-q"}, description = "Quality of Service")
+  public int qos = 0;
+
   private MQTTSNClient client;
 
   @Override
@@ -19,6 +22,11 @@ public class MQTTSNPublisher extends PublishClient {
   @Override
   protected TestClient getClient() {
     return client;
+  }
+
+  @Override
+  public void publish(String topic, String message) {
+    client.publish(topic, message, qos);
   }
 
   public static void main(String[] args) {

--- a/clients/mqtt-sn-subscriber/pom.xml
+++ b/clients/mqtt-sn-subscriber/pom.xml
@@ -45,6 +45,7 @@
                 </executions>
             </plugin>
         </plugins>
+        <finalName>${project.artifactId}</finalName>
     </build>
     <dependencies>
         <dependency>

--- a/clients/mqtt-sn-subscriber/pom.xml
+++ b/clients/mqtt-sn-subscriber/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>okse-clients</artifactId>
         <groupId>no.ntnu</groupId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>no.ntnu</groupId>
             <artifactId>clients-common</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/clients/mqtt-sn-subscriber/src/main/java/no/ntnu/okse/clients/mqttsn/MQTTSNSubscriber.java
+++ b/clients/mqtt-sn-subscriber/src/main/java/no/ntnu/okse/clients/mqttsn/MQTTSNSubscriber.java
@@ -18,7 +18,7 @@ public class MQTTSNSubscriber extends SubscribeClient {
   @Override
   protected void createClient() {
     client = new MQTTSNClient(host, port);
-    client.setCallback(new Callback());
+    client.setCallback(new Callback(this));
   }
 
   @Override
@@ -32,9 +32,15 @@ public class MQTTSNSubscriber extends SubscribeClient {
 
   private static class Callback implements SimpleMqttsCallback {
 
+    private SubscribeClient subscribeClient;
+
+    public Callback(SubscribeClient subscribeClient) {
+      this.subscribeClient = subscribeClient;
+    }
+
     @Override
     public void publishArrived(boolean ret, int qualityOfService, String topic, byte[] msg) {
-      System.out.println(String.format("Received message %s on topic %s", new String(msg), topic));
+      subscribeClient.receiveMessage(new String(msg), topic, true);
     }
 
     @Override

--- a/clients/mqtt-subscriber/pom.xml
+++ b/clients/mqtt-subscriber/pom.xml
@@ -45,6 +45,7 @@
                 </executions>
             </plugin>
         </plugins>
+        <finalName>${project.artifactId}</finalName>
     </build>
     <dependencies>
         <dependency>

--- a/clients/mqtt-subscriber/pom.xml
+++ b/clients/mqtt-subscriber/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>okse-clients</artifactId>
         <groupId>no.ntnu</groupId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>no.ntnu</groupId>
             <artifactId>clients-common</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/clients/mqtt-subscriber/src/main/java/no/ntnu/okse/clients/mqtt/MQTTSubscriber.java
+++ b/clients/mqtt-subscriber/src/main/java/no/ntnu/okse/clients/mqtt/MQTTSubscriber.java
@@ -24,7 +24,7 @@ public class MQTTSubscriber extends SubscribeClient {
 
   protected void createClient() {
     client = new MQTTClient(host, port, "MQTTSubscriber");
-    client.setCallback(new Callback());
+    client.setCallback(new Callback(this));
   }
 
   protected TestClient getClient() {
@@ -33,13 +33,18 @@ public class MQTTSubscriber extends SubscribeClient {
 
   private static class Callback implements MqttCallback {
 
+    private SubscribeClient subscribeClient;
+
+    public Callback(SubscribeClient subscribeClient) {
+      this.subscribeClient = subscribeClient;
+    }
+
     public void connectionLost(Throwable throwable) {
       log.warn("Connection lost", throwable);
     }
 
     public void messageArrived(String topic, MqttMessage message) {
-      System.out
-          .println(String.format("Message arrived on topic %s with content %s", topic, message));
+      subscribeClient.receiveMessage(topic, message.toString(), true);
     }
 
     public void deliveryComplete(IMqttDeliveryToken token) {

--- a/clients/mqtt-subscriber/src/main/java/no/ntnu/okse/clients/mqtt/MQTTSubscriber.java
+++ b/clients/mqtt-subscriber/src/main/java/no/ntnu/okse/clients/mqtt/MQTTSubscriber.java
@@ -12,7 +12,7 @@ import org.eclipse.paho.client.mqttv3.MqttMessage;
 public class MQTTSubscriber extends SubscribeClient {
 
   @Parameter(names = {"--port", "-p"}, description = "Port")
-  public final int port = 1883;
+  public int port = 1883;
 
   private MQTTClient client;
 

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>no.ntnu</groupId>
     <artifactId>okse-clients</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.0</version>
     <modules>
         <module>wsn-publisher</module>
         <module>common</module>

--- a/clients/stomp-publisher/pom.xml
+++ b/clients/stomp-publisher/pom.xml
@@ -45,6 +45,7 @@
                 </executions>
             </plugin>
         </plugins>
+        <finalName>${project.artifactId}</finalName>
     </build>
     <dependencies>
         <dependency>

--- a/clients/stomp-publisher/pom.xml
+++ b/clients/stomp-publisher/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>okse-clients</artifactId>
         <groupId>no.ntnu</groupId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>no.ntnu</groupId>
             <artifactId>clients-common</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/clients/stomp-publisher/src/main/java/no/ntnu/okse/clients/stomp/STOMPPublisher.java
+++ b/clients/stomp-publisher/src/main/java/no/ntnu/okse/clients/stomp/STOMPPublisher.java
@@ -7,7 +7,7 @@ import no.ntnu.okse.clients.TestClient;
 public class STOMPPublisher extends PublishClient {
 
   @Parameter(names = {"--port", "-p"}, description = "Port")
-  public final int port = 61613;
+  public int port = 61613;
 
   private StompClient client;
 

--- a/clients/stomp-subscriber/pom.xml
+++ b/clients/stomp-subscriber/pom.xml
@@ -45,6 +45,7 @@
                 </executions>
             </plugin>
         </plugins>
+        <finalName>${project.artifactId}</finalName>
     </build>
     <dependencies>
         <dependency>

--- a/clients/stomp-subscriber/pom.xml
+++ b/clients/stomp-subscriber/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>okse-clients</artifactId>
         <groupId>no.ntnu</groupId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>no.ntnu</groupId>
             <artifactId>clients-common</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/clients/stomp-subscriber/src/main/java/no/ntnu/okse/clients/stomp/STOMPSubscriber.java
+++ b/clients/stomp-subscriber/src/main/java/no/ntnu/okse/clients/stomp/STOMPSubscriber.java
@@ -1,5 +1,6 @@
 package no.ntnu.okse.clients.stomp;
 
+import asia.stampy.server.message.message.MessageMessage;
 import com.beust.jcommander.Parameter;
 import no.ntnu.okse.clients.SubscribeClient;
 import no.ntnu.okse.clients.TestClient;
@@ -17,10 +18,25 @@ public class STOMPSubscriber extends SubscribeClient {
 
   protected void createClient() {
     client = new StompClient(host, port);
-    client.setCallback(new StompCallback());
+    client.setCallback(new Callback(this));
   }
 
   protected TestClient getClient() {
     return client;
+  }
+
+  private static class Callback extends StompCallback {
+
+    private SubscribeClient subscribeClient;
+
+    public Callback(SubscribeClient subscribeClient) {
+      this.subscribeClient = subscribeClient;
+    }
+
+    @Override
+    public void messageReceived(MessageMessage message) {
+      subscribeClient
+          .receiveMessage(message.getHeader().getDestination(), message.getBody().toString(), true);
+    }
   }
 }

--- a/clients/stomp-subscriber/src/main/java/no/ntnu/okse/clients/stomp/STOMPSubscriber.java
+++ b/clients/stomp-subscriber/src/main/java/no/ntnu/okse/clients/stomp/STOMPSubscriber.java
@@ -7,7 +7,7 @@ import no.ntnu.okse.clients.TestClient;
 public class STOMPSubscriber extends SubscribeClient {
 
   @Parameter(names = {"--port", "-p"}, description = "Port")
-  public final int port = 61613;
+  public int port = 61613;
 
   private StompClient client;
 

--- a/clients/wsn-publisher/pom.xml
+++ b/clients/wsn-publisher/pom.xml
@@ -5,17 +5,16 @@
     <parent>
         <artifactId>okse-clients</artifactId>
         <groupId>no.ntnu</groupId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>no.ntnu</groupId>
     <artifactId>wsn-publisher</artifactId>
     <dependencies>
         <dependency>
             <groupId>no.ntnu</groupId>
             <artifactId>clients-common</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
     <packaging>jar</packaging>

--- a/clients/wsn-publisher/pom.xml
+++ b/clients/wsn-publisher/pom.xml
@@ -56,5 +56,6 @@
                 </executions>
             </plugin>
         </plugins>
+        <finalName>${project.artifactId}</finalName>
     </build>
 </project>

--- a/clients/wsn-publisher/src/main/java/no/ntnu/okse/clients/wsn/WSNPublisher.java
+++ b/clients/wsn-publisher/src/main/java/no/ntnu/okse/clients/wsn/WSNPublisher.java
@@ -7,7 +7,7 @@ import no.ntnu.okse.clients.TestClient;
 public class WSNPublisher extends PublishClient {
 
   @Parameter(names = {"--port", "-p"}, description = "Port")
-  public final int port = 61000;
+  public int port = 61000;
 
   private WSNClient client;
 

--- a/clients/wsn-publisher/src/main/java/no/ntnu/okse/clients/wsn/WSNPublisher.java
+++ b/clients/wsn-publisher/src/main/java/no/ntnu/okse/clients/wsn/WSNPublisher.java
@@ -9,6 +9,9 @@ public class WSNPublisher extends PublishClient {
   @Parameter(names = {"--port", "-p"}, description = "Port")
   public int port = 61000;
 
+  @Parameter(names = {"--host-url-extension", "-url"}, description = "Host Notification Broker url")
+  public String host_url_extension = "";
+
   private WSNClient client;
 
   public static void main(String[] args) {
@@ -16,7 +19,7 @@ public class WSNPublisher extends PublishClient {
   }
 
   public void createClient() {
-    client = new WSNClient(host, port);
+    client = new WSNClient(host, port, host_url_extension);
   }
 
   public TestClient getClient() {

--- a/clients/wsn-subscriber/pom.xml
+++ b/clients/wsn-subscriber/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>okse-clients</artifactId>
         <groupId>no.ntnu</groupId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>no.ntnu</groupId>
             <artifactId>clients-common</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
     <build>

--- a/clients/wsn-subscriber/pom.xml
+++ b/clients/wsn-subscriber/pom.xml
@@ -54,5 +54,6 @@
                 </executions>
             </plugin>
         </plugins>
+        <finalName>${project.artifactId}</finalName>
     </build>
 </project>

--- a/clients/wsn-subscriber/src/main/java/no/ntnu/okse/clients/wsn/WSNSubscriber.java
+++ b/clients/wsn-subscriber/src/main/java/no/ntnu/okse/clients/wsn/WSNSubscriber.java
@@ -18,6 +18,9 @@ public class WSNSubscriber extends SubscribeClient {
   @Parameter(names = {"--client-port", "-cp"}, description = "Client Port")
   public int clientPort = 9000;
 
+  @Parameter(names = {"--host-url-extension", "-url"}, description = "Host Notification Broker url")
+  public String host_url_extension = "";
+
   private WSNClient client;
 
   public static void main(String[] args) {
@@ -25,7 +28,7 @@ public class WSNSubscriber extends SubscribeClient {
   }
 
   protected void createClient() {
-    client = new WSNClient(host, port);
+    client = new WSNClient(host, port, host_url_extension);
     client.setCallback(new WSNConsumer());
   }
 

--- a/clients/wsn-subscriber/src/main/java/no/ntnu/okse/clients/wsn/WSNSubscriber.java
+++ b/clients/wsn-subscriber/src/main/java/no/ntnu/okse/clients/wsn/WSNSubscriber.java
@@ -10,13 +10,13 @@ import org.w3c.dom.Element;
 public class WSNSubscriber extends SubscribeClient {
 
   @Parameter(names = {"--port", "-p"}, description = "Port")
-  public final int port = 61000;
+  public int port = 61000;
 
   @Parameter(names = {"--client-host", "-ch"}, description = "Client Port")
-  public final String clientHost = "localhost";
+  public String clientHost = "localhost";
 
   @Parameter(names = {"--client-port", "-cp"}, description = "Client Port")
-  public final int clientPort = 9000;
+  public int clientPort = 9000;
 
   private WSNClient client;
 

--- a/clients/wsn-subscriber/src/main/java/no/ntnu/okse/clients/wsn/WSNSubscriber.java
+++ b/clients/wsn-subscriber/src/main/java/no/ntnu/okse/clients/wsn/WSNSubscriber.java
@@ -29,7 +29,7 @@ public class WSNSubscriber extends SubscribeClient {
 
   protected void createClient() {
     client = new WSNClient(host, port, host_url_extension);
-    client.setCallback(new WSNConsumer());
+    client.setCallback(new WSNConsumer(this));
   }
 
   protected TestClient getClient() {
@@ -42,10 +42,17 @@ public class WSNSubscriber extends SubscribeClient {
 
   private class WSNConsumer implements Consumer.Callback {
 
+    private SubscribeClient subscribeClient;
+
+    public WSNConsumer(SubscribeClient subscribeClient) {
+      this.subscribeClient = subscribeClient;
+    }
+
     public void notify(NotificationMessageHolderType message) {
       Object o = message.getMessage().getAny();
       if (o instanceof Element) {
-        System.out.println(((Element) o).getTextContent());
+        subscribeClient.receiveMessage(message.getTopic().getContent().toString(),
+            ((Element) o).getTextContent(), true);
       }
     }
   }

--- a/clients/xmpp-publisher/pom.xml
+++ b/clients/xmpp-publisher/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>okse-clients</artifactId>
         <groupId>no.ntnu</groupId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>no.ntnu</groupId>
             <artifactId>clients-common</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
     <packaging>jar</packaging>

--- a/clients/xmpp-publisher/pom.xml
+++ b/clients/xmpp-publisher/pom.xml
@@ -9,7 +9,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>no.ntnu</groupId>
     <artifactId>xmpp-publisher</artifactId>
     <dependencies>
         <dependency>
@@ -57,5 +56,6 @@
                 </executions>
             </plugin>
         </plugins>
+        <finalName>${project.artifactId}</finalName>
     </build>
 </project>

--- a/clients/xmpp-publisher/src/main/java/no/ntnu/okse/clients/xmpp/XMPPPublisher.java
+++ b/clients/xmpp-publisher/src/main/java/no/ntnu/okse/clients/xmpp/XMPPPublisher.java
@@ -12,6 +12,9 @@ public class XMPPPublisher extends PublishClient {
   @Parameter(names = {"--jid"}, description = "JID")
   public String jid = "publisher@localhost";
 
+  @Parameter(names = {"--password", "--pass"}, description = "User password")
+  public String password = "password";
+
   private XMPPClient client;
 
   public static void main(String[] args) {
@@ -20,7 +23,7 @@ public class XMPPPublisher extends PublishClient {
 
   @Override
   protected void createClient() {
-    client = new XMPPClient(host, port, jid);
+    client = new XMPPClient(host, port, jid, password);
   }
 
   @Override

--- a/clients/xmpp-publisher/src/main/java/no/ntnu/okse/clients/xmpp/XMPPPublisher.java
+++ b/clients/xmpp-publisher/src/main/java/no/ntnu/okse/clients/xmpp/XMPPPublisher.java
@@ -7,7 +7,7 @@ import no.ntnu.okse.clients.TestClient;
 public class XMPPPublisher extends PublishClient {
 
   @Parameter(names = {"--port", "-p"}, description = "Port")
-  public final int port = 5222;
+  public int port = 5222;
 
   @Parameter(names = {"--jid"}, description = "JID")
   public String jid = "publisher@localhost";

--- a/clients/xmpp-subscriber/pom.xml
+++ b/clients/xmpp-subscriber/pom.xml
@@ -9,7 +9,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>no.ntnu</groupId>
     <artifactId>xmpp-subscriber</artifactId>
     <dependencies>
         <dependency>
@@ -57,5 +56,6 @@
                 </executions>
             </plugin>
         </plugins>
+        <finalName>${project.artifactId}</finalName>
     </build>
 </project>

--- a/clients/xmpp-subscriber/pom.xml
+++ b/clients/xmpp-subscriber/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>okse-clients</artifactId>
         <groupId>no.ntnu</groupId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>3.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>no.ntnu</groupId>
             <artifactId>clients-common</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
     <packaging>jar</packaging>

--- a/clients/xmpp-subscriber/src/main/java/no.ntnu.okse.clients.xmpp/XMPPSubscriber.java
+++ b/clients/xmpp-subscriber/src/main/java/no.ntnu.okse.clients.xmpp/XMPPSubscriber.java
@@ -3,6 +3,7 @@ package no.ntnu.okse.clients.xmpp;
 import com.beust.jcommander.Parameter;
 import no.ntnu.okse.clients.SubscribeClient;
 import no.ntnu.okse.clients.TestClient;
+import no.ntnu.okse.clients.xmpp.XMPPClient.Callback;
 
 public class XMPPSubscriber extends SubscribeClient {
 
@@ -21,10 +22,25 @@ public class XMPPSubscriber extends SubscribeClient {
   @Override
   protected void createClient() {
     client = new XMPPClient(host, port, jid);
+    client.callback = new SubscriberCallback(this);
   }
 
   @Override
   protected TestClient getClient() {
     return client;
+  }
+
+  private static class SubscriberCallback implements Callback {
+
+    private SubscribeClient subscribeClient;
+
+    public SubscriberCallback(SubscribeClient subscribeClient) {
+      this.subscribeClient = subscribeClient;
+    }
+
+    @Override
+    public void onMessageReceived(String topic, String message) {
+      subscribeClient.receiveMessage(topic, message, true);
+    }
   }
 }

--- a/clients/xmpp-subscriber/src/main/java/no.ntnu.okse.clients.xmpp/XMPPSubscriber.java
+++ b/clients/xmpp-subscriber/src/main/java/no.ntnu.okse.clients.xmpp/XMPPSubscriber.java
@@ -13,6 +13,9 @@ public class XMPPSubscriber extends SubscribeClient {
   @Parameter(names = {"--jid"}, description = "JID")
   public String jid = "subscriber@localhost";
 
+  @Parameter(names = {"--password", "--pass"}, description = "User password")
+  public String password = "password";
+
   private XMPPClient client;
 
   public static void main(String[] args) {
@@ -21,7 +24,7 @@ public class XMPPSubscriber extends SubscribeClient {
 
   @Override
   protected void createClient() {
-    client = new XMPPClient(host, port, jid);
+    client = new XMPPClient(host, port, jid, password);
     client.callback = new SubscriberCallback(this);
   }
 

--- a/clients/xmpp-subscriber/src/main/java/no.ntnu.okse.clients.xmpp/XMPPSubscriber.java
+++ b/clients/xmpp-subscriber/src/main/java/no.ntnu.okse.clients.xmpp/XMPPSubscriber.java
@@ -7,7 +7,7 @@ import no.ntnu.okse.clients.TestClient;
 public class XMPPSubscriber extends SubscribeClient {
 
   @Parameter(names = {"--port", "-p"}, description = "Port")
-  public final int port = 5222;
+  public int port = 5222;
 
   @Parameter(names = {"--jid"}, description = "JID")
   public String jid = "subscriber@localhost";

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>no.ntnu</groupId>
     <artifactId>okse-parent</artifactId>
-    <version>2.0.0</version>
+    <version>3.0.0</version>
     <modules>
         <module>clients</module>
         <module>broker</module>


### PR DESCRIPTION
Several fixes to the the test clients and to the XMPP implementation

Full feature list:
- Subscribe clients have a `-n` argument to indicate how many messages they should receive before shutting down
- WSN client has an extra `-url` argument for cases where the server does not operate on the base url
- Several client arguments were set to final hindering them from changing to the given command line input
- Versions and years have been bumped to OKSE 3.0 and 2018
- MQTT-SN clients now allow `--qos` on publish and use QoS = 1 on subscribe.
- XMPP server does now longer drop messages when messages on a new topic arrive too fast
- XMPP clients have a `--password` field